### PR TITLE
Update support to PHP 8.3 and Laravel 11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Laravel Settings
 Move your env variables to database to change them easily using laravel nova
 ## Requirements
-- PHP >= 8.0
-- Laravel >= 8.0
+- PHP >= 8.3
+- Laravel >= 10.0
 - Laravel nova license registered on project
 ## Installation
 - Require package with composer:

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/database": "^9.0|^10.0",
-        "illuminate/http": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0"
+        "php": "^8.3",
+        "illuminate/database": "^10.0|^11.0",
+        "illuminate/http": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^11.2",
         "letsgoi/php-code-style": "^1.2",
-        "orchestra/testbench": "^8.17"
+        "orchestra/testbench": "^9.1"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     build: ./docker/php-cli

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-alpine
+FROM php:8.3-cli-alpine
 
 RUN apk add git
 

--- a/tests/Unit/SettingRepositoryTest.php
+++ b/tests/Unit/SettingRepositoryTest.php
@@ -7,10 +7,11 @@ use Letsgoi\LaravelSettings\Models\Setting;
 use Letsgoi\LaravelSettings\Observers\SettingObserver;
 use Letsgoi\LaravelSettings\Repository\SettingRepository;
 use Letsgoi\LaravelSettings\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SettingRepositoryTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_string()
     {
         $settingRepository = new SettingRepository();
@@ -25,7 +26,7 @@ class SettingRepositoryTest extends TestCase
         $this->assertEquals('1', $settingRepository->find('android_app_version'));
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_float()
     {
         $settingRepository = new SettingRepository();
@@ -40,7 +41,7 @@ class SettingRepositoryTest extends TestCase
         $this->assertEquals(1.5, $settingRepository->find('android_app_version'));
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_array()
     {
         $settingRepository = new SettingRepository();
@@ -55,7 +56,7 @@ class SettingRepositoryTest extends TestCase
         $this->assertEquals([1.5], $settingRepository->find('android_app_version'));
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_int()
     {
         $settingRepository = new SettingRepository();
@@ -70,7 +71,7 @@ class SettingRepositoryTest extends TestCase
         $this->assertEquals(1, $settingRepository->find('android_app_version'));
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_bool()
     {
         $settingRepository = new SettingRepository();
@@ -93,7 +94,7 @@ class SettingRepositoryTest extends TestCase
         $this->assertFalse($settingRepository->find('ios_app_version'));
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_error_if_variable_does_not_exist()
     {
         $settingRepository = new SettingRepository();
@@ -104,7 +105,7 @@ class SettingRepositoryTest extends TestCase
         $settingRepository->find('android_app_version');
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_updated_setting()
     {
         Setting::observe(SettingObserver::class);

--- a/tests/Unit/SettingTest.php
+++ b/tests/Unit/SettingTest.php
@@ -2,15 +2,13 @@
 
 namespace Letsgoi\LaravelSettings\Tests\Unit;
 
-use Exception;
 use Letsgoi\LaravelSettings\Models\Setting;
-use Letsgoi\LaravelSettings\Observers\SettingObserver;
-use Letsgoi\LaravelSettings\Repository\SettingRepository;
 use Letsgoi\LaravelSettings\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SettingTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_string()
     {
         $setting = Setting::create([
@@ -23,7 +21,7 @@ class SettingTest extends TestCase
         $this->assertEquals('string', $setting->value);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_float()
     {
         $setting = Setting::create([
@@ -36,7 +34,7 @@ class SettingTest extends TestCase
         $this->assertEquals(1.5, $setting->value);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_array()
     {
         $setting = Setting::create([
@@ -49,7 +47,7 @@ class SettingTest extends TestCase
         $this->assertEquals([1.5], $setting->value);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_int()
     {
         $setting = Setting::create([
@@ -62,7 +60,7 @@ class SettingTest extends TestCase
         $this->assertEquals(1, $setting->value);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_bool()
     {
         $settingTrue = Setting::create([


### PR DESCRIPTION
This PR:

- Adds support to PHP 8.3.
- Updates Docker image to PHP 8.3.
- Adds support to Laravel 11.
- Removes support to Laravel 9.
- Updates to PHPUnit 11. Changes annotations to attributes, as annotations will be deleted in PHPUnit 12. https://docs.phpunit.de/en/11.2/attributes.html

Private task: https://www.notion.so/69d2d4c7ecdf460f9a861660dc51b63b